### PR TITLE
Update __load_mod_descriptors with load additional modules

### DIFF
--- a/busybee/service.py
+++ b/busybee/service.py
@@ -95,20 +95,21 @@ class BusyBee:
         install_json_content = fetch_content(config["install-json-path"])
         self._install_json = json.loads(install_json_content)
         # Check for additional modules
-        additional_json_path = config["additional-json-path"]
-        if os.path.exists(additional_json_path):
-            print(f"Found additional modules from json path {additional_json_path}")
-            additional_json_content = fetch_content(additional_json_path)
-            additional_install_json = json.loads(additional_json_content)
-            json_len = len(additional_install_json)
-            
-            if json_len > 0:
-                additional_json_dump = json.dumps(additional_install_json, indent=4)
-                print(f'Preparing to append additional modules: {additional_json_dump}')
-                self._install_json += additional_install_json
-                print(f"Appended {json_len} additional modules to the list")
-            else:
-                print(f"Failed to append additional modules, the list is empty")
+        if "additional-json-path" in config: 
+            additional_json_path = config["additional-json-path"]
+            if os.path.exists(additional_json_path):
+                print(f"Found additional modules from json path {additional_json_path}")
+                additional_json_content = fetch_content(additional_json_path)
+                additional_install_json = json.loads(additional_json_content)
+                json_len = len(additional_install_json)
+                
+                if json_len > 0:
+                    additional_json_dump = json.dumps(additional_install_json, indent=4)
+                    print(f'Preparing to append additional modules: {additional_json_dump}')
+                    self._install_json += additional_install_json
+                    print(f"Appended {json_len} additional modules to the list")
+                else:
+                    print(f"Failed to append additional modules, the list is empty")
         
         registry_url = config["registry-url"]
         for module in self._install_json:

--- a/busybee/service.py
+++ b/busybee/service.py
@@ -94,6 +94,22 @@ class BusyBee:
 
         install_json_content = fetch_content(config["install-json-path"])
         self._install_json = json.loads(install_json_content)
+        # Check for additional modules
+        additional_json_path = config["additional-json-path"]
+        if os.path.exists(additional_json_path):
+            print(f"Found additional modules from json path {additional_json_path}")
+            additional_json_content = fetch_content(additional_json_path)
+            additional_install_json = json.loads(additional_json_content)
+            json_len = len(additional_install_json)
+            
+            if json_len > 0:
+                additional_json_dump = json.dumps(additional_install_json, indent=4)
+                print(f'Preparing to append additional modules: {additional_json_dump}')
+                self._install_json += additional_install_json
+                print(f"Appended {json_len} additional modules to the list")
+            else:
+                print(f"Failed to append additional modules, the list is empty")
+        
         registry_url = config["registry-url"]
         for module in self._install_json:
             module_id = module["id"]

--- a/busybee/service.py
+++ b/busybee/service.py
@@ -94,20 +94,22 @@ class BusyBee:
 
         install_json_content = fetch_content(config["install-json-path"])
         self._install_json = json.loads(install_json_content)
-        # Check for additional modules
+        
+        # Check for optional additional modules
         if "additional-json-path" in config: 
             additional_json_path = config["additional-json-path"]
+            
             if os.path.exists(additional_json_path):
                 print(f"Found additional modules from json path {additional_json_path}")
                 additional_json_content = fetch_content(additional_json_path)
                 additional_install_json = json.loads(additional_json_content)
-                json_len = len(additional_install_json)
+                additional_install_json_len = len(additional_install_json)
                 
-                if json_len > 0:
+                if additional_install_json_len > 0:
                     additional_json_dump = json.dumps(additional_install_json, indent=4)
                     print(f'Preparing to append additional modules: {additional_json_dump}')
                     self._install_json += additional_install_json
-                    print(f"Appended {json_len} additional modules to the list")
+                    print(f"Appended {additional_install_json_len} additional modules to the list")
                 else:
                     print(f"Failed to append additional modules, the list is empty")
         

--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,10 @@
 okapi-url: http://localhost:9130
 registry-url: http://folio-registry.dev.folio.org
 install-json-path: https://raw.githubusercontent.com/folio-org/platform-complete/snapshot/install.json  # A file path to install.json can also be used
+# A file path to your additional json file that can be used to deploy additional modules not usually included in install.json
+# Example additional_modules.json: 
+#   [ { "id" : "mod-consortia-1.2.0-SNAPSHOT", "action" : "enable" } ]
+# additional-json-path: /home/user/.busybee/additional_modules.json 
 env-vars: # any key-pairs added here will be added to the OKAPI env service
   DB_PASSWORD: folio_admin
   DB_USERNAME: folio_admin


### PR DESCRIPTION
## Purpose

- Deploy custom, additional modules that are not usually present in <https://raw.githubusercontent.com/folio-org/platform-complete/snapshot/install.json>, allowing us to still use the latest SNAPSHOT versions of each module found in `install.json`, together with any additional modules as defined by `install-json-path`.

## Approach

- Use a separate `json` file for custom module lookup
- Be minimally intrusive with the main functionality