### PR TITLE
Add exit codes and start exception handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,42 +2,78 @@
 
 BusyBee is a command-line interface application designed to manage and deploy FOLIO modules in a dynamic and efficient manner. Built on Python and utilizing the cmd2 library, BusyBee offers a range of commands for deploying, undeploying, and managing redirects for different modules.
 
-# Features
+## Features
+
 - Module Descriptors Caching: Caches module descriptors to improve performance and efficiency.
 - Tenant and User Management: Supports creating tenants and tenant admin users, including setting permissions and environment variables.
 - Module Deployment and Management: Facilitates deploying, undeploying, and managing modules, including HTTP redirection.
 - Autocompletion of commands and module names on the CLI.
 
-# Usage 
-```
+## Usage
+
+```shell
 pip install -r requirements.txt
 python -m busybee
 ```
 
-# Build Executable From Source
+> Upgrade dependencies using `pip install -r requirements.txt -U`.
+
+## Build Executable From Source
 
 To build executable from source, clone the repository and install the required dependencies:
-```
+
+```shell
 python build.py
 ```
+
 Executable will be located in the `dist` folder.
 
-# Configuration
+## Configuration
+
 Upon first run, if the configuration is missing, BusyBee CLI will generate a template configuration file at a specified path. Update this file with the necessary details before proceeding.
 
-# Available Commands
-- start: Initializes the environment and creates a tenant with enabled modules.
-- deploy: Deploys a specified module. Usage: `deploy -m MODULE_NAME`
-- undeploy: Undeploys a specified module. Usage: `undeploy -m MODULE_NAME`
-- redirect: Manages HTTP redirects for a module. Usage: `redirect -m MODULE_NAME [-l LOCATION | -rm]`
-> MODULE_NAME should be present in the BusyBee configuration file. 
-- reload: Reloads the config file and rebuilds the mod descriptors cache
-Usage: `reload`
-- create_tenant: Create a new tenant with modules in BusyBee configuration file. Usage: `create_tenant -id TENANT_ID [-n TENANT_NAME] [-d TENANT_DESCRIPTION] [-i INCLUDED_MODULES | -e EXCLUDED_MODULES]`
->Example: `create_tenant -id test1 -e mod-copycat,mod-login-saml`
-- delete_tenant: Deletes a tenant. Usage: `delete_tenant -id TENANT_ID`
-- help: Show available commands
-- quit: Exit the application
+## Available Commands
 
+- `start`: Initializes the environment and creates a tenant with enabled modules.
+- `deploy`: Deploys a specified module. Usage:
 
+```shell
+deploy -m MODULE_NAME
+```
 
+- `undeploy`: Undeploys a specified module. Usage:
+
+```shell
+undeploy -m MODULE_NAME
+```
+
+- `redirect`: Manages HTTP redirects for a module. Usage:
+
+> MODULE_NAME should be present in the BusyBee configuration file.
+
+```shell
+redirect -m MODULE_NAME [-l LOCATION | -rm]
+```
+
+- `reload`: Reloads the config file and rebuilds the mod descriptors cache. Usage:
+
+```shell
+reload
+```
+
+- `create_tenant`: Create a new tenant with modules in BusyBee configuration file. Usage:
+
+```shell
+create_tenant -id TENANT_ID [-n TENANT_NAME] [-d TENANT_DESCRIPTION] [-i INCLUDED_MODULES | -e EXCLUDED_MODULES]
+```
+
+> Example: `create_tenant -id test1 -e mod-copycat,mod-login-saml`
+
+- `delete_tenant`: Deletes a tenant. Usage:
+
+```shell
+delete_tenant -id TENANT_ID
+```
+
+- `help`: Show available commands
+- `quit`: Exit the application

--- a/busybee/cli.py
+++ b/busybee/cli.py
@@ -31,18 +31,18 @@ class BusyBeeCli(cmd2.Cmd):
         try:
             self.busybee = BusyBee()
         except MissingConfigurationException as e:
-            self.perror(f'Could not start BusyBee: {e}')
+            self.perror(f'Could not init BusyBee, missing configuration exception: {e}')
             config_path = os.path.normpath(os.path.abspath(gen_config()))
             self.poutput(f'Update configuration file generated at {config_path}')
-            sys.exit()
+            sys.exit(2)
         except JSONDecodeError as e:
             error_message = "A JSONDecodeError occurred: " + str(e)
             error_message += "\nThe problematic JSON string is:\n" + e.doc
             self.perror(error_message)
             sys.exit()
         except Exception as e:
-            self.perror(f'Could not start BusyBee: {e}')
-            sys.exit()
+            self.perror(f'Could not init BusyBee, exception: {e}')
+            sys.exit(2)
 
         self.poutput("Ready for your commands!")
 
@@ -56,11 +56,15 @@ class BusyBeeCli(cmd2.Cmd):
     @cmd2.with_category(CMD_ENV_OPS)
     def do_start(self, arg):
         """Initializes the environment and creates a tenant with enabled modules"""
-        self.busybee.set_module_env_vars()
-        self.busybee.register_modules()
-        self.busybee.create_tenant()
-        self.busybee.enable_modules_for_tenant()
-        self.busybee.create_tenant_admin()
+        try:
+            self.busybee.set_module_env_vars()
+            self.busybee.register_modules()
+            self.busybee.create_tenant()
+            self.busybee.enable_modules_for_tenant()
+            self.busybee.create_tenant_admin()
+        except Exception as e:
+            self.perror(f'Could not start BusyBee, exception: {e}')
+            sys.exit(2)  
 
     deploy_argparser = cmd2.Cmd2ArgumentParser()
     deploy_argparser.add_argument(

--- a/busybee/cli.py
+++ b/busybee/cli.py
@@ -34,7 +34,7 @@ class BusyBeeCli(cmd2.Cmd):
             self.perror(f'Could not init BusyBee, missing configuration exception: {e}')
             config_path = os.path.normpath(os.path.abspath(gen_config()))
             self.poutput(f'Update configuration file generated at {config_path}')
-            sys.exit(2)
+            sys.exit(1)
         except JSONDecodeError as e:
             error_message = "A JSONDecodeError occurred: " + str(e)
             error_message += "\nThe problematic JSON string is:\n" + e.doc
@@ -42,7 +42,7 @@ class BusyBeeCli(cmd2.Cmd):
             sys.exit()
         except Exception as e:
             self.perror(f'Could not init BusyBee, exception: {e}')
-            sys.exit(2)
+            sys.exit(1)
 
         self.poutput("Ready for your commands!")
 
@@ -64,7 +64,7 @@ class BusyBeeCli(cmd2.Cmd):
             self.busybee.create_tenant_admin()
         except Exception as e:
             self.perror(f'Could not start BusyBee, exception: {e}')
-            sys.exit(2)  
+            sys.exit(1)  
 
     deploy_argparser = cmd2.Cmd2ArgumentParser()
     deploy_argparser.add_argument(


### PR DESCRIPTION
## Purpose

- Add exit codes and start exception handling to allow for automated restarts using `$?` or exit code trapping
- Do a general-purpose README.md update to align with the VSCode recommended linting

## Approach

- Add explicit exit code 1 in case of failures
- Add start exception handling