### PR TITLE
set default memory limit for launch descriptors to 1 GB

### DIFF
--- a/busybee/service.py
+++ b/busybee/service.py
@@ -172,6 +172,8 @@ class BusyBee:
         for module in modules.values():
             module_id = module["id"]
             module_descriptor = module["desc"]
+            if "launchDescriptor" in module_descriptor:
+                module_descriptor["launchDescriptor"]["dockerArgs"]["HostConfig"]["Memory"] = 1073741824  # 1 GB in bytes default for all
             if "mod-consortia" in modules and "mod-authtoken" in module_id:
                 env_vars = module_descriptor["launchDescriptor"]["env"]
                 for env_var in env_vars:


### PR DESCRIPTION
For Mac users, solution will fix suddenly modules being shutdown because of mem limit
![image](https://github.com/user-attachments/assets/19b0acdf-5eb5-4f83-a8e6-c58d8035b383)

It will not affect overall mem usage but it will not shutdown if module use more memory than expected

as a result every module is now launched with 1GB mem limit
![image](https://github.com/user-attachments/assets/4c75711b-3258-419a-b936-fa454f19eb35)


